### PR TITLE
Add handling for non-confluent rewrite rules and use in reduction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +551,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "frunk 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "gloo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1298,6 +1307,7 @@ dependencies = [
 "checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 "checksum http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+"checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1ecfa3b81afc64d9a6539c4eece96ac9a93c551c713a313800dade8e33d7b5c1"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ petgraph = "0.4.13"
 sha2 = "0.8.1"
 varisat = "0.2.1"
 xml-rs = "0.8.0"
+itertools = "0.9.0"
 
 jni = { version = "0.10.2", optional = true }
 yew = { version = "0.13", optional = true }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -67,6 +67,8 @@ use std::collections::{HashSet, HashMap};
 use std::collections::BTreeSet;
 use std::mem;
 
+use itertools::Itertools;
+
 /// Symbol for unary operations
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[repr(C)]
@@ -458,6 +460,63 @@ impl Expr {
         })
     }
 
+    /// Like `transform_expr_inner()` but both the parameter and return types
+    /// are `Box<Expr>` instead of `Expr`
+    fn box_transform_expr_inner<Trans>(expr: Box<Expr>, trans: &Trans) -> (Box<Expr>, bool)
+    where Trans: Fn(Expr) -> (Expr, bool) {
+	let (result, status) = Self::transform_expr_inner(*expr, trans);
+	return (Box::new(result), status);
+    }
+
+    /// Helper function for `tranform()`; use the `trans` function to transform
+    /// `expr`, yielding a tuple of the transformed expression and a `bool`
+    /// indicating whether the expression can be transformed again.
+    fn transform_expr_inner<Trans>(expr: Expr, trans: &Trans) -> (Expr, bool)
+    where Trans: Fn(Expr) -> (Expr, bool) {
+        use Expr::*;
+
+	let (result, status) = trans(expr);
+	let (result, status2) = match result {
+	    // Base cases: these just got transformed above so no need to recurse them
+	    e @ Contradiction => (e, false),
+	    e @ Tautology => (e, false),
+	    e @ Var { .. } => (e, false),
+
+	    // Recursive cases: transform each of the sub-expressions of the various compound expressions
+	    // and then construct a new instance of that compound expression with their transformed results.
+	    // If any transformation is successful, we return success
+	    Apply { func, args } => {
+		let (func, fs) = Self::box_transform_expr_inner(func, trans);
+		// Fancy iterator hackery to transform each sub expr and then collect all their results
+		let (args, stats) : (Vec<_>, Vec<_>) = args.into_iter().map(move |expr| Self::transform_expr_inner(expr, trans)).unzip();
+		let success = fs || stats.into_iter().any(|x| x);
+		(Apply { func, args }, success)
+	    },
+	    Unop { symbol, operand } => {
+		let (operand, success) = Self::box_transform_expr_inner(operand, trans);
+		(Unop { symbol, operand }, success)
+	    },
+	    Binop { symbol, left, right } => {
+		let (left, ls) = Self::box_transform_expr_inner(left, trans);
+		let (right, rs) = Self::box_transform_expr_inner(right, trans);
+		let success = ls || rs;
+		(Binop { symbol, left, right }, success)
+	    },
+	    AssocBinop { symbol, exprs } => {
+		let (exprs, stats): (Vec<_>, Vec<_>) = exprs.into_iter().map(move |expr| Self::transform_expr_inner(expr, trans)).unzip();
+		let success = stats.into_iter().any(|x| x);
+		(AssocBinop { symbol, exprs }, success)
+	    },
+	    Quantifier { symbol, name, body } => {
+		let (body, success) = Self::box_transform_expr_inner(body, trans);
+		(Quantifier { symbol, name, body }, success)
+	    },
+	};
+	// The key to this function is that it returns true if ANYTHING was transformed. That means
+	// if either the whole expression or any of the inner expressions, we should re-run on everything.
+	(result, status || status2)
+    }
+
     /// Recursive transforming visitor over an expression
     /// trans_fn is a function that takes an Expr and returns one of two things:
     /// 1. If this expression is not transformable, (original expr, false)
@@ -469,69 +528,131 @@ impl Expr {
     /// that it matches.
     pub fn transform<Trans>(self, trans_fn: &Trans) -> Expr
     where Trans: Fn(Expr) -> (Expr, bool) {
-        use Expr::*;
-
-        // Because I don't like typing
-        fn box_transform_expr_inner<Trans>(expr: Box<Expr>, trans: &Trans) -> (Box<Expr>, bool)
-        where Trans: Fn(Expr) -> (Expr, bool) {
-            let (result, status) = transform_expr_inner(*expr, trans);
-            return (Box::new(result), status);
-        }
-
-        fn transform_expr_inner<Trans>(expr: Expr, trans: &Trans) -> (Expr, bool)
-        where Trans: Fn(Expr) -> (Expr, bool) {
-            let (result, status) = trans(expr);
-            let (result, status2) = match result {
-                // Base cases: these just got transformed above so no need to recurse them
-                e @ Contradiction => (e, false),
-                e @ Tautology => (e, false),
-                e @ Var { .. } => (e, false),
-
-                // Recursive cases: transform each of the sub-expressions of the various compound expressions
-                // and then construct a new instance of that compound expression with their transformed results.
-                // If any transformation is successful, we return success
-                Apply { func, args } => {
-                    let (func, fs) = box_transform_expr_inner(func, trans);
-                    // Fancy iterator hackery to transform each sub expr and then collect all their results
-                    let (args, stats) : (Vec<_>, Vec<_>) = args.into_iter().map(move |expr| transform_expr_inner(expr, trans)).unzip();
-                    let success = fs || stats.into_iter().any(|x| x);
-                    (Apply { func, args }, success)
-                },
-                Unop { symbol, operand } => {
-                    let (operand, success) = box_transform_expr_inner(operand, trans);
-                    (Unop { symbol, operand }, success)
-                },
-                Binop { symbol, left, right } => {
-                    let (left, ls) = box_transform_expr_inner(left, trans);
-                    let (right, rs) = box_transform_expr_inner(right, trans);
-                    let success = ls || rs;
-                    (Binop { symbol, left, right }, success)
-                },
-                AssocBinop { symbol, exprs } => {
-                    let (exprs, stats): (Vec<_>, Vec<_>) = exprs.into_iter().map(move |expr| transform_expr_inner(expr, trans)).unzip();
-                    let success = stats.into_iter().any(|x| x);
-                    (AssocBinop { symbol, exprs }, success)
-                },
-                Quantifier { symbol, name, body } => {
-                    let (body, success) = box_transform_expr_inner(body, trans);
-                    (Quantifier { symbol, name, body }, success)
-                },
-            };
-            // The key to this function is that it returns true if ANYTHING was transformed. That means
-            // if either the whole expression or any of the inner expressions, we should re-run on everything.
-            (result, status || status2)
-        }
-
         // Worklist: Keep reducing and transforming as long as something changes. This will loop infinitely
         // if your transformation creates patterns that it matches.
-        let (mut result, mut status) = transform_expr_inner(self, trans_fn);
+        let (mut result, mut status) = Self::transform_expr_inner(self, trans_fn);
         while status {
             // Rust pls
-            let (x, y) = transform_expr_inner(result, trans_fn);
+            let (x, y) = Self::transform_expr_inner(result, trans_fn);
             result = x;
             status = y;
         }
         result
+    }
+
+    /// Like `transform_set()`, but the result is converted to a vector. This is
+    /// used because `itertools::Itertools::cartesian_product` requires `Clone`,
+    /// which `std::collections::hash_set::IntoIter` doesn't implement.
+    fn transform_set_vec<Trans>(self, trans_fn: &Trans) -> Vec<Expr>
+    where Trans: Fn(Expr) -> (Expr, bool) {
+	self.transform_set(trans_fn).into_iter().collect()
+    }
+
+    /// Recursive transforming visitor over an expression, yielding a set of
+    /// possible transformations. The parameter `trans_fn` takes an Expr and
+    /// returns one of two things:
+    ///
+    ///   1. If this expression is not transformable, (original expr, false)
+    ///   2. If this expression is transformable, (transformed expr, true)
+    ///
+    /// This should be used for non-confluent rewriting rules, and `transform()`
+    /// should be used for confluent rewriting rules.
+    pub fn transform_set<Trans>(self, trans_fn: &Trans) -> HashSet<Expr>
+    where Trans: Fn(Expr) -> (Expr, bool) {
+	use Expr::*;
+
+	let mut set = HashSet::new();
+
+	// Add all incremental normalization levels to set. Keep transforming
+	// the expression and adding the result to the set, until the expression
+	// is not transformable.
+	{
+	    let mut expr = self;
+	    let mut normable = true;
+	    set.insert(expr.clone());
+	    while normable {
+		let result = trans_fn(expr.clone());
+		expr = result.0;
+		normable = result.1;
+		set.insert(expr.clone());
+	    }
+	}
+
+	// Now that all incremental normalization levels are in the set,
+	// recursively run this on all sub-nodes of the expression.
+	for expr in set.clone() {
+	    match expr {
+		// Base case: no sub-nodes
+		Contradiction => {}
+		Tautology => {}
+		Var { .. } => {}
+
+		// Add the Cartesian product of the set of `func`
+		// transformations and the sets of transformations of `args`
+		Apply { func, args } => {
+		    let func_set = func
+			.transform_set(trans_fn)
+			.into_iter()
+			.map(Box::new);
+		    let args_set = args
+			.into_iter()
+			.map(|arg| arg.transform_set_vec(trans_fn))
+			.multi_cartesian_product();
+		    set.extend(
+			func_set
+			    .cartesian_product(args_set)
+			    .map(|(func, args)| Apply { func, args })
+		    );
+		}
+
+		// Add the set of transformations of `operand`
+		Unop { symbol, operand } => {
+		    set.extend(
+			operand
+			    .transform_set(trans_fn)
+			    .into_iter()
+			    .map(Box::new)
+			    .map(move |operand| Unop { symbol, operand })
+		    );
+		}
+
+		// Add the Cartesian product of the transformation sets of the
+		// `left` and `right` sub-nodes
+		Binop { symbol, left, right } => {
+		    let left_set = left.transform_set(trans_fn).into_iter().map(Box::new);
+		    let right_set = right.transform_set_vec(trans_fn).into_iter().map(Box::new);
+		    let binop_set = left_set
+			.cartesian_product(right_set)
+			.map(|(left, right)| Binop { symbol, left, right });
+		    set.extend(binop_set);
+		}
+
+		// Add the Cartesian product of the transformation sets of the
+		// sub-nodes in `exprs`
+		AssocBinop { symbol, exprs } => {
+		    set.extend(
+			exprs
+			    .into_iter()
+			    .map(|expr| expr.transform_set_vec(trans_fn))
+			    .multi_cartesian_product()
+			    .map(|exprs| AssocBinop { symbol, exprs })
+		    );
+		}
+
+		// Add the set of transformations of `body`
+		Quantifier { symbol, name, body } => {
+		    let body_set = body.transform_set(trans_fn).into_iter().map(Box::new);
+		    let quant_set = body_set.map(|body| Quantifier {
+			symbol,
+			name: name.clone(),
+			body,
+		    });
+		    set.extend(quant_set);
+		}
+	    }
+	}
+
+	set
     }
 
     /// Simplify an expression with recursive DeMorgan's

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate petgraph;
 extern crate sha2;
 extern crate varisat;
 extern crate xml;
+extern crate itertools;
 
 pub mod zipper_vec;
 use zipper_vec::*;

--- a/src/proofs/proof_tests.rs
+++ b/src/proofs/proof_tests.rs
@@ -806,6 +806,8 @@ pub fn test_reduction<P: Proof>() -> (P, Vec<PJRef<P>>, Vec<PJRef<P>>) {
     let p4 = prf.add_premise(p("~B | (A & ~~B)"));
     let p5 = prf.add_premise(p("(forall A, (A & (~A | B))) | (~(forall A, (A & (~A | B))) & C)"));
     let p6 = prf.add_premise(p("B & (C | (~C & ~A))"));
+    let p7 = prf.add_premise(p("A | (~A & (~~A | B))"));
+    let p8 = prf.add_premise(p("D | (~A & (~~A | B))"));
 
     let r1 = prf.add_step(Justification(p("A & B"), RuleM::Reduction, vec![i(p1.clone())], vec![]));
     let r2 = prf.add_step(Justification(p("~A & B"), RuleM::Reduction, vec![i(p2.clone())], vec![]));
@@ -820,8 +822,10 @@ pub fn test_reduction<P: Proof>() -> (P, Vec<PJRef<P>>, Vec<PJRef<P>>) {
 
     let r10 = prf.add_step(Justification(p("B & (C | ~A)"), RuleM::Reduction, vec![i(p6.clone())], vec![]));
     let r11 = prf.add_step(Justification(p("B & (C & ~A)"), RuleM::Reduction, vec![i(p6.clone())], vec![]));
+    let r12 = prf.add_step(Justification(p("A | (~A & B)"), RuleM::Reduction, vec![i(p7.clone())], vec![]));
+    let r13 = prf.add_step(Justification(p("D | (~A & B)"), RuleM::Reduction, vec![i(p8.clone())], vec![]));
 
-    (prf, vec![i(r1), i(r2), i(r3), i(r4), i(r5), i(r10)], vec![i(r6), i(r7), i(r8), i(r9), i(r11)])
+    (prf, vec![i(r1), i(r2), i(r3), i(r4), i(r5), i(r10), i(r12), i(r13)], vec![i(r6), i(r7), i(r8), i(r9), i(r11)])
 }
 
 pub fn test_adjacency<P: Proof>() -> (P, Vec<PJRef<P>>, Vec<PJRef<P>>) {


### PR DESCRIPTION
* Fixes issue with `A | (~A & (~~A | B))` not reducing to `A | (~A & B)`
* Adds test cases to `test_reduction`
* Currently only used in `RuleM::Reduction` but can be added to more rewrite rules later