### PR TITLE
Add handling for non-confluent rewrite rules and use in reduction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +551,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "frunk 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "gloo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1298,6 +1307,7 @@ dependencies = [
 "checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 "checksum http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+"checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1ecfa3b81afc64d9a6539c4eece96ac9a93c551c713a313800dade8e33d7b5c1"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ petgraph = "0.4.13"
 sha2 = "0.8.1"
 varisat = "0.2.1"
 xml-rs = "0.8.0"
+itertools = "0.9.0"
 
 jni = { version = "0.10.2", optional = true }
 yew = { version = "0.13", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate petgraph;
 extern crate sha2;
 extern crate varisat;
 extern crate xml;
+extern crate itertools;
 
 pub mod zipper_vec;
 use zipper_vec::*;

--- a/src/proofs/proof_tests.rs
+++ b/src/proofs/proof_tests.rs
@@ -806,6 +806,8 @@ pub fn test_reduction<P: Proof>() -> (P, Vec<PJRef<P>>, Vec<PJRef<P>>) {
     let p4 = prf.add_premise(p("~B | (A & ~~B)"));
     let p5 = prf.add_premise(p("(forall A, (A & (~A | B))) | (~(forall A, (A & (~A | B))) & C)"));
     let p6 = prf.add_premise(p("B & (C | (~C & ~A))"));
+    let p7 = prf.add_premise(p("A | (~A & (~~A | B))"));
+    let p8 = prf.add_premise(p("D | (~A & (~~A | B))"));
 
     let r1 = prf.add_step(Justification(p("A & B"), RuleM::Reduction, vec![i(p1.clone())], vec![]));
     let r2 = prf.add_step(Justification(p("~A & B"), RuleM::Reduction, vec![i(p2.clone())], vec![]));
@@ -820,8 +822,10 @@ pub fn test_reduction<P: Proof>() -> (P, Vec<PJRef<P>>, Vec<PJRef<P>>) {
 
     let r10 = prf.add_step(Justification(p("B & (C | ~A)"), RuleM::Reduction, vec![i(p6.clone())], vec![]));
     let r11 = prf.add_step(Justification(p("B & (C & ~A)"), RuleM::Reduction, vec![i(p6.clone())], vec![]));
+    let r12 = prf.add_step(Justification(p("A | (~A & B)"), RuleM::Reduction, vec![i(p7.clone())], vec![]));
+    let r13 = prf.add_step(Justification(p("D | (~A & B)"), RuleM::Reduction, vec![i(p8.clone())], vec![]));
 
-    (prf, vec![i(r1), i(r2), i(r3), i(r4), i(r5), i(r10)], vec![i(r6), i(r7), i(r8), i(r9), i(r11)])
+    (prf, vec![i(r1), i(r2), i(r3), i(r4), i(r5), i(r10), i(r12), i(r13)], vec![i(r6), i(r7), i(r8), i(r9), i(r11)])
 }
 
 pub fn test_adjacency<P: Proof>() -> (P, Vec<PJRef<P>>, Vec<PJRef<P>>) {

--- a/src/rewrite_rules.rs
+++ b/src/rewrite_rules.rs
@@ -26,6 +26,12 @@ impl RewriteRule {
     pub fn reduce(&self, e: Expr) -> Expr {
         reduce_pattern(e, &self.reductions)
     }
+
+    /// Reduce an expression with the rewrite rule's reductions, yielding a set
+    /// of possible reductions
+    pub fn reduce_set(&self, e: Expr) -> HashSet<Expr> {
+        reduce_pattern_set(e, &self.reductions)
+    }
 }
 
 
@@ -168,13 +174,70 @@ fn permute_patterns(patterns: Vec<(Expr, Expr)>) -> Vec<(Expr, Expr)> {
 /// let patterns = vec![(pattern1, replace1), (pattern2, replace2)];
 /// reduce_pattern(var("some_expr"), &patterns);
 /// ```
-pub fn reduce_pattern(e: Expr, patterns: &Vec<(Expr, Expr)>) -> Expr {
+pub fn reduce_pattern(e: Expr, patterns: &[(Expr, Expr)]) -> Expr {
+    let patterns = freevarsify_pattern(&e, patterns);
+    e.transform(&|expr| reduce_transform_func(expr, &patterns))
+}
+
+/// Like `reduce_pattern()`, but creates a set of possible reductions. This set
+/// will contain all levels of reduction (up to full normalization), and on all
+/// sub-nodes of the expression.
+pub fn reduce_pattern_set(e: Expr, patterns: &[(Expr, Expr)]) -> HashSet<Expr> {
+    let patterns = freevarsify_pattern(&e, patterns);
+    e.transform_set(&|expr| reduce_transform_func(expr, &patterns))
+}
+
+/// Helper function for `reduce_pattern()` and `reduce_pattern_set()`; try to
+/// reduce `expr` using `patterns`. The returned `bool` in the tuple indicates
+/// whether the transformation can be done again.
+///
+/// Parameters:
+///   * `expr` - expression to reduce
+///   * `patterns` - patterns returned by `freevarsify_pattern()`
+fn reduce_transform_func(expr: Expr, patterns: &[(Expr, Expr, HashSet<String>)]) -> (Expr, bool) {
+    // Try all our patterns at every level of the tree
+    for (pattern, replace, pattern_vars) in patterns {
+        // Unify3D
+        let ret = unify(vec![Constraint::Equal(pattern.clone(), expr.clone())].into_iter().collect());
+        if let Some(ret) = ret {
+            // Collect all unification results and make sure we actually match exactly
+            let mut subs = HashMap::new();
+            let mut any_bad = false;
+            for subst in ret.0 {
+                // We only want to unify our pattern variables. This prevents us from going backwards
+                // and unifying a pattern variable in expr with some expression of our pattern variable
+                if pattern_vars.contains(&subst.0) {
+                    // Sanity check: Only one unification per variable
+                    assert!(subs.insert(subst.0, subst.1).is_none());
+                } else {
+                    any_bad = true;
+                }
+            }
+
+            // Make sure we have a substitution for every variable in the pattern set (and only for them)
+            if !any_bad && subs.len() == pattern_vars.len() {
+                let subst_replace = subs.into_iter().fold(replace.clone(), |z, (x, y)| subst(&z, &x, y));
+                return (subst_replace, true);
+            }
+        }
+    }
+    (expr, false)
+}
+
+/// Helper function for `reduce_pattern()` and `reduce_pattern_set()`; given an
+/// expression `e` and a slice of (`pattern`, `replace`) pairs, get a vector of
+/// (`new_pattern`, `new_replace`, `pattern_vars`), where:
+///
+///   * `new_pattern` is the old `pattern` with all free variables in `e` renamed to fresh variables
+///   * `new_replace` is the old `replace` with the renames in `new_pattern`
+///   * `pattern_vars` is the set of free variables in `new_pattern`
+fn freevarsify_pattern(e: &Expr, patterns: &[(Expr, Expr)]) -> Vec<(Expr, Expr, HashSet<String>)> {
     use expression_builders::*;
 
-    let e_free = freevars(&e);
+    let e_free = freevars(e);
 
     // Find all free variables in the patterns and map them to generated names free for e
-    let patterns = patterns.iter().map(|(pattern, replace)| {
+    patterns.iter().map(|(pattern, replace)| {
         let mut pattern = pattern.clone();
         let mut replace = replace.clone();
         let free_pattern = freevars(&pattern);
@@ -193,35 +256,5 @@ pub fn reduce_pattern(e: Expr, patterns: &Vec<(Expr, Expr)>) -> Expr {
         }
 
         (pattern, replace, pattern_vars)
-    }).collect::<Vec<_>>();
-
-    e.transform(&|expr| {
-        // Try all our patterns at every level of the tree
-        for (pattern, replace, pattern_vars) in &patterns {
-            // Unify3D
-            let ret = unify(vec![Constraint::Equal(pattern.clone(), expr.clone())].into_iter().collect());
-            if let Some(ret) = ret {
-                // Collect all unification results and make sure we actually match exactly
-                let mut subs = HashMap::new();
-                let mut any_bad = false;
-                for subst in ret.0 {
-                    // We only want to unify our pattern variables. This prevents us from going backwards
-                    // and unifying a pattern variable in expr with some expression of our pattern variable
-                    if pattern_vars.contains(&subst.0) {
-                        // Sanity check: Only one unification per variable
-                        assert!(subs.insert(subst.0, subst.1).is_none());
-                    } else {
-                        any_bad = true;
-                    }
-                }
-
-                // Make sure we have a substitution for every variable in the pattern set (and only for them)
-                if !any_bad && subs.len() == pattern_vars.len() {
-                    let subst_replace = subs.into_iter().fold(replace.clone(), |z, (x, y)| subst(&z, &x, y));
-                    return (subst_replace, true);
-                }
-            }
-        }
-        (expr, false)
-    })
+    }).collect::<Vec<_>>()
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -815,8 +815,27 @@ where F: Fn(Expr) -> Expr {
     else { Err(ProofCheckError::Other(format!("{} and {} are not equal.", p, q))) }
 }
 
-fn check_by_rewrite_rule<P: Proof>(p: &P, deps: Vec<PJRef<P>>, conclusion: Expr, commutative: bool, rule: &RewriteRule) -> Result<(), ProofCheckError<PJRef<P>, P::SubproofReference>> {
+fn check_by_rewrite_rule_confl<P: Proof>(p: &P, deps: Vec<PJRef<P>>, conclusion: Expr, commutative: bool, rule: &RewriteRule) -> Result<(), ProofCheckError<PJRef<P>, P::SubproofReference>> {
     check_by_normalize_first_expr(p, deps, conclusion, commutative, |e| rule.reduce(e))
+}
+
+fn check_by_rewrite_rule_non_confl<P: Proof>(p: &P, deps: Vec<PJRef<P>>, conclusion: Expr, commutative: bool, rule: &RewriteRule) -> Result<(), ProofCheckError<PJRef<P>, P::SubproofReference>> {
+    let premise = p.lookup_expr_or_die(&deps[0])?;
+    let premise_set = rule.reduce_set(premise.clone());
+    let conclusion_set = rule.reduce_set(conclusion.clone());
+    let (premise_set, conclusion_set) = if commutative {
+        let sort_ops = |set: HashSet<Expr>| set.into_iter().map(Expr::sort_commutative_ops).collect();
+        (sort_ops(premise_set), sort_ops(conclusion_set))
+    } else {
+        (premise_set, conclusion_set)
+    };
+    // The premise and conclusion are equal if the set intersection is nonempty
+    let is_eq = premise_set.intersection(&conclusion_set).next().is_some();
+    if is_eq {
+        Ok(())
+    } else {
+        Err(ProofCheckError::Other(format!("{} and {} are not equal.", premise, conclusion)))
+    }
 }
 
 impl RuleT for Equivalence {
@@ -850,18 +869,18 @@ impl RuleT for Equivalence {
             Association => check_by_normalize_first_expr(p, deps, conclusion, false, |e| e.combine_associative_ops()),
             Commutation => check_by_normalize_first_expr(p, deps, conclusion, false, |e| e.sort_commutative_ops()),
             Idempotence => check_by_normalize_first_expr(p, deps, conclusion, false, |e| e.normalize_idempotence()),
-            DoubleNegation => check_by_rewrite_rule(p, deps, conclusion, false, &DOUBLE_NEGATION_RULES),
+            DoubleNegation => check_by_rewrite_rule_confl(p, deps, conclusion, false, &DOUBLE_NEGATION_RULES),
             // Distribution and Reduction have outputs containing binops that need commutative sorting
             // because we can't expect people to know the specific order of outputs that our definition
             // of the rules uses
-            Distribution => check_by_rewrite_rule(p, deps, conclusion, true, &DISTRIBUTION_RULES),
-            Complement => check_by_rewrite_rule(p, deps, conclusion, false, &COMPLEMENT_RULES),
-            Identity => check_by_rewrite_rule(p, deps, conclusion, false, &IDENTITY_RULES),
-            Annihilation => check_by_rewrite_rule(p, deps, conclusion, false, &ANNIHILATION_RULES),
-            Inverse => check_by_rewrite_rule(p, deps, conclusion, false, &INVERSE_RULES),
-            Absorption => check_by_rewrite_rule(p, deps, conclusion, false, &ABSORPTION_RULES),
-            Reduction => check_by_rewrite_rule(p, deps, conclusion, true, &REDUCTION_RULES),
-            Adjacency => check_by_rewrite_rule(p, deps, conclusion, false, &ADJACENCY_RULES),
+            Distribution => check_by_rewrite_rule_confl(p, deps, conclusion, true, &DISTRIBUTION_RULES),
+            Complement => check_by_rewrite_rule_confl(p, deps, conclusion, false, &COMPLEMENT_RULES),
+            Identity => check_by_rewrite_rule_confl(p, deps, conclusion, false, &IDENTITY_RULES),
+            Annihilation => check_by_rewrite_rule_confl(p, deps, conclusion, false, &ANNIHILATION_RULES),
+            Inverse => check_by_rewrite_rule_confl(p, deps, conclusion, false, &INVERSE_RULES),
+            Absorption => check_by_rewrite_rule_confl(p, deps, conclusion, false, &ABSORPTION_RULES),
+            Reduction => check_by_rewrite_rule_non_confl(p, deps, conclusion, true, &REDUCTION_RULES),
+            Adjacency => check_by_rewrite_rule_confl(p, deps, conclusion, false, &ADJACENCY_RULES),
         }
     }
 }
@@ -893,19 +912,19 @@ impl RuleT for ConditionalEquivalence {
     fn check<P: Proof>(self, p: &P, conclusion: Expr, deps: Vec<PJRef<P>>, _sdeps: Vec<P::SubproofReference>) -> Result<(), ProofCheckError<PJRef<P>, P::SubproofReference>> {
         use ConditionalEquivalence::*;
         match self {
-            Complement => check_by_rewrite_rule(p, deps, conclusion, false, &CONDITIONAL_COMPLEMENT_RULES),
-            Identity => check_by_rewrite_rule(p, deps, conclusion, false, &CONDITIONAL_IDENTITY_RULES),
-            Annihilation => check_by_rewrite_rule(p, deps, conclusion, false, &CONDITIONAL_ANNIHILATION_RULES),
-            Implication => check_by_rewrite_rule(p, deps, conclusion, false, &CONDITIONAL_IMPLICATION_RULES),
-            BiImplication => check_by_rewrite_rule(p, deps, conclusion, false, &CONDITIONAL_BIIMPLICATION_RULES),
-            Contraposition => check_by_rewrite_rule(p, deps, conclusion, false, &CONDITIONAL_CONTRAPOSITION_RULES),
-            Currying => check_by_rewrite_rule(p, deps, conclusion, false, &CONDITIONAL_CURRYING_RULES),
-            ConditionalDistribution => check_by_rewrite_rule(p, deps, conclusion, true, &CONDITIONAL_DISTRIBUTION_RULES),
-            ConditionalReduction => check_by_rewrite_rule(p, deps, conclusion, true, &CONDITIONAL_REDUCTION_RULES),
-            KnightsAndKnaves => check_by_rewrite_rule(p, deps, conclusion, true, &KNIGHTS_AND_KNAVES_RULES),
-            ConditionalIdempotence => check_by_rewrite_rule(p, deps, conclusion, true, &CONDITIONAL_IDEMPOTENCE_RULES),
-            BiconditionalNegation => check_by_rewrite_rule(p, deps, conclusion, true, &BICONDITIONAL_NEGATION_RULES),
-            BiconditionalSubstitution => check_by_rewrite_rule(p, deps, conclusion, true, &BICONDITIONAL_SUBSTITUTION_RULES)
+            Complement => check_by_rewrite_rule_confl(p, deps, conclusion, false, &CONDITIONAL_COMPLEMENT_RULES),
+            Identity => check_by_rewrite_rule_confl(p, deps, conclusion, false, &CONDITIONAL_IDENTITY_RULES),
+            Annihilation => check_by_rewrite_rule_confl(p, deps, conclusion, false, &CONDITIONAL_ANNIHILATION_RULES),
+            Implication => check_by_rewrite_rule_confl(p, deps, conclusion, false, &CONDITIONAL_IMPLICATION_RULES),
+            BiImplication => check_by_rewrite_rule_confl(p, deps, conclusion, false, &CONDITIONAL_BIIMPLICATION_RULES),
+            Contraposition => check_by_rewrite_rule_confl(p, deps, conclusion, false, &CONDITIONAL_CONTRAPOSITION_RULES),
+            Currying => check_by_rewrite_rule_confl(p, deps, conclusion, false, &CONDITIONAL_CURRYING_RULES),
+            ConditionalDistribution => check_by_rewrite_rule_confl(p, deps, conclusion, true, &CONDITIONAL_DISTRIBUTION_RULES),
+            ConditionalReduction => check_by_rewrite_rule_confl(p, deps, conclusion, true, &CONDITIONAL_REDUCTION_RULES),
+            KnightsAndKnaves => check_by_rewrite_rule_confl(p, deps, conclusion, true, &KNIGHTS_AND_KNAVES_RULES),
+            ConditionalIdempotence => check_by_rewrite_rule_confl(p, deps, conclusion, true, &CONDITIONAL_IDEMPOTENCE_RULES),
+            BiconditionalNegation => check_by_rewrite_rule_confl(p, deps, conclusion, true, &BICONDITIONAL_NEGATION_RULES),
+            BiconditionalSubstitution => check_by_rewrite_rule_confl(p, deps, conclusion, true, &BICONDITIONAL_SUBSTITUTION_RULES)
         }
     }
 }


### PR DESCRIPTION
* Fixes issue with `A | (~A & (~~A | B))` not reducing to `A | (~A & B)`
* Adds test cases to `test_reduction()`
* Currently only used in `RuleM::Reduction` but can be added to more rewrite rules later