### PR TITLE
Equal Size UI

### DIFF
--- a/web-app/src/components/proof_widget.rs
+++ b/web-app/src/components/proof_widget.rs
@@ -341,13 +341,13 @@ impl ProofWidget {
                 <div class="dropdown">
                     <button
                         type="button"
-                        class="btn btn-secondary dropdown-toggle"
+                        class="btn btn-secondary"
                         id="dropdownMenuButton"
                         data-toggle="dropdown"
                         aria-haspopup="true"
                         aria-expanded="false">
 
-                        { "Action" }
+                        { "\u{22EE}" }
                     </button>
                     <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                         { options }

--- a/web-app/src/components/proof_widget.rs
+++ b/web-app/src/components/proof_widget.rs
@@ -232,19 +232,19 @@ impl ProofWidget {
             Some(x) => x,
         };
         match parse(&raw_line).map(|_| self.prf.verify_line(&proofref)) {
-            None => html! { <span class="alert alert-warning small-alert">{ "Parse error" }</span> },
+            None => html! { <span class="alert alert-warning small-alert s1">{ "Parse error" }</span> },
             Some(Ok(())) => match proofref {
                 Coproduct::Inl(_) => html! {
-                    <span class="alert alert-success small-alert">
+                    <span class="alert alert-success small-alert s2">
                         { if is_subproof { "Assumption" } else { "Premise" } }
                     </span>
                 },
-                _ => html! { <span class="alert small-alert bg-success text-white">{ "Correct" }</span> },
+                _ => html! { <span class="alert small-alert bg-success text-white s1">{ "Correct" }</span> },
             },
             Some(Err(err)) => {
                 html! {
                     <>
-                        <button type="button" class="btn btn-danger" data-toggle="popover" data-content=err>
+                        <button type="button" class="btn btn-danger s1" data-toggle="popover" data-content=err>
                             { "Error" }
                         </button>
                         <script>

--- a/web-app/static/styles.css
+++ b/web-app/static/styles.css
@@ -39,3 +39,15 @@ html, body {
     width: 400px;
     color: black;
 }
+
+/* Used to make "Correct", "Error", and "Parse Error" the same size. */
+.s1 {
+    width: 106px;
+    text-align: center;
+}
+
+/* Used to make "Premise" and "Assumption" the same size. */
+.s2 {
+    width: 112px;
+    text-align: center;
+}


### PR DESCRIPTION
Makes certain elements the same size as others in the column and make the action selector a symbol instead of words.