### PR TITLE
Remove www from url in CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.aris.bram-hub.com
+aris.bram-hub.com


### PR DESCRIPTION
The CNAME file should not have www at the start. The subdomain is aris so there is no need. Then people can just go to `https://aris.bram-hub.com` to view the website. For example we have https://willow.bram-hub.com

Also make sure you switch the github pages url to remove the www. I cannot do that with a PR

After that it should just work