### PR TITLE
Suppress redundant closure

### DIFF
--- a/aris/src/proofs.rs
+++ b/aris/src/proofs.rs
@@ -187,9 +187,11 @@ pub type JsRef<P> = Coprod!(<P as Proof>::JustificationReference, <P as Proof>::
 pub type PjsRef<P> = Coprod!(<P as Proof>::PremiseReference, <P as Proof>::JustificationReference, <P as Proof>::SubproofReference);
 type JustVal<P> = Justification<Expr, PjRef<P>, <P as Proof>::SubproofReference>;
 
+#[allow(clippy::redundant_closure)]
 pub fn js_to_pjs<P: Proof>(js: JsRef<P>) -> PjsRef<P> {
     js.fold(hlist![|x| Coproduct::inject(x), |x| Coproduct::inject(x)])
 }
+#[allow(clippy::redundant_closure)]
 pub fn pj_to_pjs<P: Proof>(pj: PjRef<P>) -> PjsRef<P> {
     pj.fold(hlist![|x| Coproduct::inject(x), |x| Coproduct::inject(x)])
 }

--- a/aris/src/rules.rs
+++ b/aris/src/rules.rs
@@ -495,6 +495,8 @@ impl RuleT for PrepositionalInference {
             OrElim | BiconditionalIntro | EquivalenceIntro => None,
         }
     }
+
+    #[allow(clippy::redundant_closure)]
     fn check<P: Proof>(self, p: &P, conclusion: Expr, deps: Vec<PjRef<P>>, sdeps: Vec<P::SubproofReference>) -> Result<(), ProofCheckError<PjRef<P>, P::SubproofReference>> {
         use PrepositionalInference::*;
         use ProofCheckError::*;


### PR DESCRIPTION
The fixes proposed by Clippy are non-functional in the contexts.
Chose to suppress the warnings to allow for testing to pass
without warning.